### PR TITLE
Fix wrong logic after refactoring on shader code

### DIFF
--- a/dist/src/main/kotlin/kr/toxicity/hud/manager/ShaderManagerImpl.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/manager/ShaderManagerImpl.kt
@@ -159,7 +159,7 @@ object ShaderManagerImpl : BetterHudManager, ShaderManager {
             if (yaml.getAsBoolean("disable-level-text", false)) replaceList += "HideExp"
 
             yaml["hotbar"]?.asObject()?.let {
-                if (it.getAsBoolean("disable", false)) {
+                if (!it.getAsBoolean("disable", false)) {
                     replaceList += "RemapHotBar"
                     val locations =
                         it.get("locations")?.asObject().ifNull { "locations configuration not set." }


### PR DESCRIPTION
After refactoring, there's an error where hotbar position modification is enabled if `disable` is `true` (???). This PR fixes that.