### PR TITLE
fix: call reload events under async

### DIFF
--- a/bootstrap/bukkit/src/main/kotlin/kr/toxicity/hud/bootstrap/bukkit/BukkitBootstrapImpl.kt
+++ b/bootstrap/bukkit/src/main/kotlin/kr/toxicity/hud/bootstrap/bukkit/BukkitBootstrapImpl.kt
@@ -98,10 +98,14 @@ class BukkitBootstrapImpl : BukkitBootstrap, JavaPlugin() {
     private val core = BetterHudImpl(this).apply {
         BetterHudAPI.inst(this)
         addReloadStartTask {
-            PluginReloadStartEvent().call()
+            scheduler.asyncTask {
+                PluginReloadStartEvent().call()
+            }
         }
         addReloadEndTask {
-            PluginReloadedEvent(it).call()
+            scheduler.asyncTask {
+                PluginReloadedEvent(it).call()
+            }
         }
         addReloadStartTask {
             HandlerList.unregisterAll(listener)


### PR DESCRIPTION
Using the latest version of Nexo, Paper and BetterHUD results in `java.lang.IllegalStateException: PluginReloadStartEvent may only be triggered asynchronously.`

This PR will change event triggering to be under async context.

This has only been tested on Paper 1.21.4