### PR TITLE
feat: add flow layout support to LayoutComponentContainer

### DIFF
--- a/dist/src/main/kotlin/kr/toxicity/hud/component/LayoutComponentContainer.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/component/LayoutComponentContainer.kt
@@ -3,6 +3,7 @@ package kr.toxicity.hud.component
 import kr.toxicity.hud.api.component.PixelComponent
 import kr.toxicity.hud.api.component.WidthComponent
 import kr.toxicity.hud.layout.enums.LayoutAlign
+import kr.toxicity.hud.layout.enums.LayoutFlow
 import kr.toxicity.hud.layout.enums.LayoutOffset
 import kr.toxicity.hud.util.EMPTY_WIDTH_COMPONENT
 import kr.toxicity.hud.util.toSpaceComponent
@@ -10,11 +11,15 @@ import kr.toxicity.hud.util.toSpaceComponent
 class LayoutComponentContainer(
     private val offset: LayoutOffset,
     private val align: LayoutAlign,
+    private val flow: LayoutFlow,
+    private val flowGap: Int,
     private val max: Int
 ) {
     private var comp = EMPTY_WIDTH_COMPONENT
+    private var flowComp = EMPTY_WIDTH_COMPONENT
+    private var flowElementCount = 0
 
-    private fun append(other: PixelComponent) {
+    private fun appendAbsolute(other: PixelComponent) {
         val move = when (align) {
             LayoutAlign.LEFT -> 0
             LayoutAlign.CENTER -> (max - other.component.width) / 2
@@ -23,18 +28,46 @@ class LayoutComponentContainer(
         comp += (other.pixel + move).toSpaceComponent() + other.component + (-other.pixel - other.component.width - move).toSpaceComponent()
     }
 
+    private fun appendFlow(other: PixelComponent) {
+        // In flow mode, we concatenate elements sequentially
+        // Add gap before element (except for the first one)
+        if (flowElementCount > 0 && flowGap > 0) {
+            flowComp += flowGap.toSpaceComponent()
+        }
+        flowComp += other.component
+        flowElementCount++
+    }
+
     fun append(others: List<PixelComponent>): LayoutComponentContainer {
-        others.forEach {
-            append(it)
+        when (flow) {
+            LayoutFlow.NONE -> others.forEach { appendAbsolute(it) }
+            LayoutFlow.HORIZONTAL -> others.forEach { appendFlow(it) }
+            LayoutFlow.VERTICAL -> {
+                // For vertical flow, each element starts at origin (handled by their individual y offsets)
+                others.forEach { appendAbsolute(it) }
+            }
         }
         return this
     }
 
     fun build(): WidthComponent {
-        return when (offset) {
-            LayoutOffset.LEFT -> 0
-            LayoutOffset.CENTER -> -max / 2
-            LayoutOffset.RIGHT -> -max
-        }.toSpaceComponent() + comp
+        return when (flow) {
+            LayoutFlow.NONE, LayoutFlow.VERTICAL -> {
+                when (offset) {
+                    LayoutOffset.LEFT -> 0
+                    LayoutOffset.CENTER -> -max / 2
+                    LayoutOffset.RIGHT -> -max
+                }.toSpaceComponent() + comp
+            }
+            LayoutFlow.HORIZONTAL -> {
+                // For horizontal flow, center the concatenated content based on its actual width
+                val totalWidth = flowComp.width
+                when (offset) {
+                    LayoutOffset.LEFT -> 0
+                    LayoutOffset.CENTER -> -totalWidth / 2
+                    LayoutOffset.RIGHT -> -totalWidth
+                }.toSpaceComponent() + flowComp
+            }
+        }
     }
 }

--- a/dist/src/main/kotlin/kr/toxicity/hud/hud/HudParser.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/hud/HudParser.kt
@@ -47,7 +47,7 @@ class HudParser(
         return Runner {
             if (conditions(player)) {
                 val f = player.tick
-                LayoutComponentContainer(layout.offset, layout.align, max)
+                LayoutComponentContainer(layout.offset, layout.align, layout.flow, layout.flowGap, max)
                     .append(renderer.map {
                         it(f)
                     })

--- a/dist/src/main/kotlin/kr/toxicity/hud/layout/LayoutGroup.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/layout/LayoutGroup.kt
@@ -4,6 +4,7 @@ import kr.toxicity.command.BetterCommandSource
 import kr.toxicity.hud.api.yaml.YamlObject
 import kr.toxicity.hud.configuration.HudConfiguration
 import kr.toxicity.hud.layout.enums.LayoutAlign
+import kr.toxicity.hud.layout.enums.LayoutFlow
 import kr.toxicity.hud.layout.enums.LayoutOffset
 import kr.toxicity.hud.animation.AnimationLocation
 import kr.toxicity.hud.location.PixelLocation
@@ -32,6 +33,14 @@ class LayoutGroup(
             it.handle(sender, "Unable to find that offset: $it")
         }.getOrNull()
     } ?: LayoutOffset.CENTER
+    val flow = section["flow"]?.asString()?.let {
+        runCatching {
+            LayoutFlow.valueOf(it.uppercase())
+        }.onFailure {
+            it.handle(sender, "Unable to find that flow: $it")
+        }.getOrNull()
+    } ?: LayoutFlow.NONE
+    val flowGap = section.getAsInt("flow-gap", 0)
 
     val image = section["images"]?.asObject()?.mapSubConfiguration { s, yamlObject ->
         ImageLayout.Impl(s, this, yamlObject, loc)

--- a/dist/src/main/kotlin/kr/toxicity/hud/layout/enums/LayoutFlow.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/layout/enums/LayoutFlow.kt
@@ -1,0 +1,7 @@
+package kr.toxicity.hud.layout.enums
+
+enum class LayoutFlow {
+    NONE,
+    HORIZONTAL,
+    VERTICAL
+}

--- a/dist/src/main/kotlin/kr/toxicity/hud/popup/PopupLayout.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/popup/PopupLayout.kt
@@ -93,7 +93,7 @@ class PopupLayout(
                 }
                 Runner {
                     val frame = frameSupplier()
-                    LayoutComponentContainer(layout.offset, layout.align, max)
+                    LayoutComponentContainer(layout.offset, layout.align, layout.flow, layout.flowGap, max)
                         .append(result.map {
                             it(frame)
                         })


### PR DESCRIPTION
## Description

This PR adds a new **flow mode** feature for layout groups, enabling elements to automatically concatenate horizontally and be centered as a group. This is particularly useful for dynamic HUDs where text length varies (timers, counters, player names, etc.).

### Problem

Currently, each element in a layout group requires manual x/y positioning. When dealing with dynamic content like placeholders, it's impossible to predict the final width, making it difficult to properly center grouped elements.

### Solution

Added a `flow` property to `LayoutGroup` that controls how elements are arranged:

| Flow Mode | Behavior |
|-----------|----------|
| `none` (default) | Existing behavior - absolute x/y positioning |
| `horizontal` | Elements concatenate left-to-right, ignoring x positions |
| `vertical` | Reserved for future vertical stacking |

When combined with `offset: center`, horizontal flow mode automatically centers the combined elements based on their actual rendered width.

Also added `flow-gap` property to specify pixel spacing between elements in flow mode.

### Usage Example

```yaml
top_row:
  flow: horizontal
  flow-gap: 10
  offset: center
  texts:
    1:
      name: default_font
      pattern: " <image:icon> [papi:player_name] "
    2:
      name: default_font
      pattern: " [papi:some_value] "
```
