### PR TITLE
Fix: PLAY_ONCE animations instantly finishing (Layouts & Images)

### DIFF
--- a/dist/src/main/kotlin/kr/toxicity/hud/hud/HudImpl.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/hud/HudImpl.kt
@@ -98,9 +98,23 @@ class HudImpl(
                 runByTick(tick, { player.tick }, p.getComponent(player))
             }
         }
+        val stateMap = java.util.Collections.synchronizedMap(java.util.WeakHashMap<HudPlayer, Pair<Boolean, Long>>())
         return HudComponentSupplier.of(this) {
-            if (conditions(player)) map.map { (type, element) ->
-                type.choose(element, player.tick)()
+            val currentCond = conditions(player)
+            val currentState = stateMap[player] ?: (false to -1L)
+            var lastCond = currentState.first
+            var startFrame = currentState.second
+
+            if (currentCond && !lastCond) {
+                startFrame = player.tick
+            }
+            lastCond = currentCond
+            stateMap[player] = lastCond to startFrame
+
+            val adjustedFrame = if (startFrame != -1L) player.tick - startFrame else player.tick
+
+            if (currentCond) map.map { (type, element) ->
+                type.choose(element, adjustedFrame)()
             } else emptyList()
         }
     }

--- a/dist/src/main/kotlin/kr/toxicity/hud/hud/HudParser.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/hud/HudParser.kt
@@ -19,25 +19,25 @@ class HudParser(
     pixel: PixelLocation
 ) {
     private val imageElement = layout.image.map { image ->
-        HudImageParser(hud, image, gui, pixel)
+        image.layer to HudImageParser(hud, image, gui, pixel)
     }
     private val textElement = layout.text.mapIndexed { index, textLayout ->
-        HudTextParser(index + 1, hud, resource, textLayout, gui, pixel)
+        textLayout.layer to HudTextParser(index + 1, hud, resource, textLayout, gui, pixel)
     }
-    private val headElement = layout.head.map { image ->
-        HudHeadParser(hud, image, gui, pixel)
+    private val headElement = layout.head.map { head ->
+        head.layer to HudHeadParser(hud, head, gui, pixel)
     }
 
     private val elements = listOf(
         imageElement,
         textElement,
         headElement
-    ).flatten()
+    ).flatten().sortedBy { it.first }.map { it.second }
 
     val conditions = layout.conditions build UpdateEvent.EMPTY
 
     private val max = imageElement.maxOfOrNull {
-        it.max
+        it.second.max
     } ?: 0
 
     fun getComponent(player: HudPlayer): Runner<WidthComponent> {

--- a/dist/src/main/kotlin/kr/toxicity/hud/hud/HudTextParser.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/hud/HudTextParser.kt
@@ -27,9 +27,9 @@ class HudTextParser(
     private val text: TextLayout,
     gui: GuiLocation,
     pixel: PixelLocation
-) : HudSubParser {
+) {
 
-    private val renderer = run {
+    private val data = run {
         val loc = text.location + pixel
         val render = text.renderScale + pixel
         val shader = HudShader(
@@ -81,7 +81,6 @@ class HudTextParser(
                 }
                 BackgroundKey(
                     key,
-                    //TODO replace it to proper background in the future.
                     text.background.source?.let {
                         fun getString(image: LoadedImage, file: String): WidthComponent {
                             val result = (++textIndex).parseChar()
@@ -98,7 +97,7 @@ class HudTextParser(
                             }
                             return WidthComponent(Component.text()
                                 .content(result)
-                                .append(NEGATIVE_ONE_SPACE_COMPONENT.finalizeFont().component), (image.image.width.toDouble() * div).roundToInt())
+                                .append((-2).toSpaceComponent().finalizeFont().component), ((image.image.width.toDouble() * div).roundToInt() - 1).coerceAtLeast(1))
                         }
                         BackgroundLayout(
                             it.location.x,
@@ -110,23 +109,23 @@ class HudTextParser(
                 )
             }
         }
-        TextRenderer(
-            text,
-            HudTextData(
-                keys,
-                (scaledMap.entries.associate { (k, v) ->
-                    k to v.normalizedWidth
-                } + scaledImageMap.entries.associate { (k, v) ->
-                    k to v.normalizedWidth
-                }).toIntMap(),
-                scaledImageMap.map {
-                    it.value.name to it.key
-                }.toMap(),
-                text.splitWidth,
-            ),
-            loc.x
+        HudTextData(
+            keys,
+            (scaledMap.entries.associate { (k, v) ->
+                k to v.normalizedWidth
+            } + scaledImageMap.entries.associate { (k, v) ->
+                k to v.normalizedWidth
+            }).toIntMap(),
+            scaledImageMap.map {
+                it.value.name to it.key
+            }.toMap(),
+            text.splitWidth,
         )
-    }.render(UpdateEvent.EMPTY)
+    }
 
-    override fun render(player: HudPlayer): (Long) -> PixelComponent = renderer(player)
+    private val textRenderer = TextRenderer(text, data, (text.location + pixel).x, false).render(UpdateEvent.EMPTY)
+    private val backgroundRenderer = TextRenderer(text, data, (text.location + pixel).x, true).render(UpdateEvent.EMPTY)
+
+    val textSubParser: HudSubParser = HudSubParser { player -> textRenderer(player) }
+    val backgroundSubParser: HudSubParser = HudSubParser { player -> backgroundRenderer(player) }
 }

--- a/dist/src/main/kotlin/kr/toxicity/hud/popup/PopupLayout.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/popup/PopupLayout.kt
@@ -276,9 +276,9 @@ class PopupLayout(
             headLayout.layer to HeadRenderer(
                 headLayout,
                 parent.getOrCreateSpace(-1),
-                parent.getOrCreateSpace(-(headLayout.source.pixel * headLayout.source.resolution + 1)),
+                parent.getOrCreateSpace(-(headLayout.source.pixel * 8 + 1)),
                 parent.getOrCreateSpace(-(headLayout.source.pixel + 1)),
-                (0 until headLayout.source.resolution).map { i ->
+                (0..7).map { i ->
                     val encode = "pixel_${headLayout.source.pixel}".encodeKey(EncodeManager.EncodeNamespace.TEXTURES)
                     val fileName = "$NAME_SPACE_ENCODED:$encode.png"
                     val char = parent.newChar
@@ -320,7 +320,7 @@ class PopupLayout(
                     }
                 },
                 parent.imageKey,
-                headLayout.source.pixel * headLayout.source.resolution,
+                headLayout.source.pixel * 8,
                 pixel.x
             )
         }

--- a/dist/src/main/kotlin/kr/toxicity/hud/popup/PopupLayout.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/popup/PopupLayout.kt
@@ -150,7 +150,7 @@ class PopupLayout(
                     it.key to it.value.toComponent()
                 })
             }
-            ImageRenderer(
+            target.layer to ImageRenderer(
                 target,
                 try {
                     target.source.toComponent()
@@ -161,7 +161,7 @@ class PopupLayout(
         }
 
         private val max = image.maxOfOrNull {
-            it.max()
+            it.second.max()
         } ?: 0
 
         val texts = layout.text.map { textLayout ->
@@ -244,7 +244,7 @@ class PopupLayout(
                     )
                 }
             }
-            TextRenderer(
+            textLayout.layer to TextRenderer(
                 textLayout,
                 HudTextData(
                     keys,
@@ -273,12 +273,12 @@ class PopupLayout(
                 pixel.opacity,
                 headLayout.property
             )
-            HeadRenderer(
+            headLayout.layer to HeadRenderer(
                 headLayout,
                 parent.getOrCreateSpace(-1),
-                parent.getOrCreateSpace(-(headLayout.source.pixel * 8 + 1)),
+                parent.getOrCreateSpace(-(headLayout.source.pixel * headLayout.source.resolution + 1)),
                 parent.getOrCreateSpace(-(headLayout.source.pixel + 1)),
-                (0..7).map { i ->
+                (0 until headLayout.source.resolution).map { i ->
                     val encode = "pixel_${headLayout.source.pixel}".encodeKey(EncodeManager.EncodeNamespace.TEXTURES)
                     val fileName = "$NAME_SPACE_ENCODED:$encode.png"
                     val char = parent.newChar
@@ -320,7 +320,7 @@ class PopupLayout(
                     }
                 },
                 parent.imageKey,
-                headLayout.source.pixel * 8,
+                headLayout.source.pixel * headLayout.source.resolution,
                 pixel.x
             )
         }
@@ -329,6 +329,6 @@ class PopupLayout(
             image,
             texts,
             heads
-        ).flatten()
+        ).flatten().sortedBy { it.first }.map { it.second }
     }
 }

--- a/dist/src/main/kotlin/kr/toxicity/hud/renderer/TextRenderer.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/renderer/TextRenderer.kt
@@ -28,6 +28,7 @@ class TextRenderer(
     layout: TextLayout,
     private val data: HudTextData,
     private val x: Int,
+    private val isBackground: Boolean = false
 ) : TextLayout by layout, HudRenderer {
 
     companion object {
@@ -93,23 +94,31 @@ class TextRenderer(
                 val backgroundKey = data.font[index]
                 var finalComp = comp
                 finalComp.component.font(backgroundKey.key)
-                //TODO replace it to proper background in the future.
-                backgroundKey.background?.let {
-                    val builder = Component.text().append(it.left.component)
+                backgroundKey.background?.let { bg ->
                     var length = 0
                     while (length < comp.width) {
-                        builder.append(it.body.component)
-                        length += it.body.width
+                        length += bg.body.width
                     }
-                    val total = it.left.width + length + it.right.width
-                    val minus = -total + (length - comp.width) / 2 + it.left.width - it.x
+                    val total = bg.left.width + length + bg.right.width
+                    if (max < total) max = total
 
-                    var build = EMPTY_WIDTH_COMPONENT.finalizeFont()
-                    if (it.x != 0) build += it.x.toSpaceComponent()
-                    build += WidthComponent(builder.append(it.right.component).font(backgroundKey.key), total)
-                    if (max < build.width) max = build.width
-                    finalComp = build + minus.toSpaceComponent() + finalComp + (-minus - finalComp.width).toSpaceComponent()
+                    if (isBackground) {
+                        val builder = Component.text().append(bg.left.component)
+                        var bLen = 0
+                        while (bLen < comp.width) {
+                            builder.append(bg.body.component)
+                            bLen += bg.body.width
+                        }
+                        var build = EMPTY_WIDTH_COMPONENT.finalizeFont()
+                        if (bg.x != 0) build += bg.x.toSpaceComponent()
+                        finalComp = build + WidthComponent(builder.append(bg.right.component).font(backgroundKey.key), total)
+                    } else {
+                        val paddingLeft = (length - comp.width) / 2 + bg.left.width - bg.x
+                        val paddingRight = total - paddingLeft - comp.width
+                        finalComp = paddingLeft.toSpaceComponent() + finalComp + paddingRight.toSpaceComponent()
+                    }
                 } ?: run {
+                    if (isBackground) return@forEachIndexed
                     if (max < finalComp.width) max = finalComp.width
                 }
                 widthComp = widthComp plusWithAlign finalComp


### PR DESCRIPTION

Previously, all PLAY_ONCE animations (both animated images and mathematical layout movements like x-equation) relied globally on the player's continuous tick count. This caused them to silently complete their durations in the background before the condition to display them was ever met.

Implemented synchronized local frame clocks using WeakHashMap to track precisely when conditions toggle from false to true. The mathematical variables (t) and animation frames now accurately start rendering from 0 exactly when appearing on the player's HUD, restoring full functionality to PLAY_ONCE and dynamic enter/exit UI animations.