### PR TITLE
Fix/circle split listener min

### DIFF
--- a/dist/src/main/kotlin/kr/toxicity/hud/image/enums/SplitType.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/image/enums/SplitType.kt
@@ -80,7 +80,8 @@ enum class SplitType {
         override fun split(target: NamedLoadedImage, split: Int): List<NamedLoadedImage> {
             val saveName = target.name.substringBefore('.')
             return (1..split).map {
-                val targetImage = target.image.circleCut(2 * PI * it.toDouble() / split.toDouble()) ?: throw RuntimeException()
+                val targetImage = target.image.circleCut(2 * PI * it.toDouble() / split.toDouble())
+                    ?: LoadedImage(BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), target.image.xOffset, target.image.yOffset)
                 NamedLoadedImage(
                     "${saveName}_$it.png",
                     targetImage
@@ -92,7 +93,8 @@ enum class SplitType {
         override fun split(target: NamedLoadedImage, split: Int): List<NamedLoadedImage> {
             val saveName = target.name.substringBefore('.')
             return (1..split).map {
-                val targetImage = target.image.circleCut(2 * PI * it.toDouble() / split.toDouble(), true) ?: throw RuntimeException()
+                val targetImage = target.image.circleCut(2 * PI * it.toDouble() / split.toDouble(), true)
+                    ?: LoadedImage(BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), target.image.xOffset, target.image.yOffset)
                 NamedLoadedImage(
                     "${saveName}_$it.png",
                     targetImage

--- a/dist/src/main/kotlin/kr/toxicity/hud/manager/ListenerManagerImpl.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/manager/ListenerManagerImpl.kt
@@ -32,13 +32,15 @@ object ListenerManagerImpl : BetterHudManager, ListenerManager {
             val source = PlaceholderSource.Impl(c)
             val v = PlaceholderManagerImpl.find(c["value"]?.asString().ifNull { "value value not set." }, source)
             val m = PlaceholderManagerImpl.find(c["max"]?.asString().ifNull { "max value not set." }, source)
+            val minValue = c["min"]?.asDouble() ?: 0.0
             return@placeholder { event ->
                 val value = v build event
                 val max = m build event
                 if (value.clazz == max.clazz && value.clazz == JavaNumber::class.java) {
                     HudListener {
                         runCatching {
-                            (value(it) as Number).toDouble() / (max(it) as Number).toDouble()
+                            val ratio = (value(it) as Number).toDouble() / (max(it) as Number).toDouble()
+                            minValue + ratio * (1.0 - minValue)
                         }.getOrNull() ?: 0.0
                     }
                 } else throw RuntimeException("this type is not a number: ${value.clazz.simpleName} and ${max.clazz.simpleName}")


### PR DESCRIPTION
## Changes

### fix: CIRCLE/REVERSE_CIRCLE crash with high split values
When using `split: 15` or higher on small images (e.g. 32x32), the circular
arc for the first few frames is too small to cover any opaque pixel in the
image. `circleCut()` calls `removeEmptyWidth()` which returns `null` in that
case — previously this triggered an unconditional `RuntimeException` and
prevented the image from loading entirely.

Now falls back to a 1x1 transparent image for those frames instead of
crashing, which correctly renders as "nothing" for a 0% cooldown state.

### feat: optional `min` parameter for placeholder listener
Adds a `min` field (default `0.0`) to the `placeholder` listener. The final
display ratio becomes:

  min + (value / max) * (1 - min)

Useful for semicircle cooldown icons that should start at half-filled instead
of empty, without needing a hardcoded max value.

Example:
  listener:
    class: placeholder
    value: "(number)papi:some_cd_value"
    max: "(number)papi:some_cd_max"
    min: 0.5
