### PR TITLE
fix(bukkit): shade expiringmap to avoid broken runtime classloader injection

### DIFF
--- a/bootstrap/bukkit/build.gradle.kts
+++ b/bootstrap/bukkit/build.gradle.kts
@@ -27,6 +27,13 @@ dependencies {
 
     shade(libs.bstats.bukkit)
     shade(libs.kotlinStdlib)
+    // expiringmap is normally fetched at runtime by DependencyInjector, but on some
+    // Paper/Purpur builds the reflective addURL/Unsafe classloader injection it falls back
+    // to silently has no effect, so PlayerHeadManager's <clinit> throws
+    // NoClassDefFoundError(net.jodah.expiringmap.ExpiringMap) on every enable even though
+    // the jar is present in .libraries. Shading it in at build time removes the dependency
+    // on that runtime injection path entirely.
+    shade("net.jodah:expiringmap:0.5.11")
 
     compileOnly(libs.adventure.platform.bukkit)
     compileOnly(shade(fileTree("shaded"))!!)


### PR DESCRIPTION
## Summary

`DependencyInjector` loads runtime dependencies (like `expiringmap`) by reflectively calling `URLClassLoader#addURL` on the plugin's classloader, falling back to a `sun.misc.Unsafe`-based hack that mutates `URLClassPath`'s internal `unopenedUrls`/`path` fields when the reflective `addURL` is blocked by the JPMS module system (JDK 17+ without `--add-opens java.base/java.net=ALL-UNNAMED`).

On some Paper/Purpur builds (reproduced on **Purpur 26.1.2, Java 25**) that `Unsafe` fallback runs without throwing, but has no effect on the plugin's actual classloader — so any class that's only ever added at runtime through this path never becomes resolvable. Concretely, this makes `PlayerHeadManager`'s `<clinit>` throw on every plugin enable:

```
java.lang.NoClassDefFoundError: net/jodah/expiringmap/ExpiringMap
	at kr.toxicity.hud.manager.PlayerHeadManager.<clinit>(PlayerHeadManager.kt:35)
	at kr.toxicity.hud.bootstrap.bukkit.BukkitBootstrapImpl.onEnable(BukkitBootstrapImpl.kt:231)
```

even though `expiringmap-0.5.11.jar` is already downloaded and present on disk in `plugins/BetterHud/.libraries/net/jodah/expiringmap/0.5.11/`.

## Fix

Shade `net.jodah:expiringmap:0.5.11` directly into the bukkit jar at build time (unrelocated — same package layout `DependencyInjector`/`BetterHudDependency` already expect, since `EXPIRING_MAP.relocate == false`). This removes the dependency on the runtime classloader-injection path for this specific class, so it's always resolvable regardless of what the host JVM/Paper build allows reflectively.

I did not touch `DependencyInjector` itself since I don't have a fix for the underlying `Unsafe` fallback that's safe across the range of JDKs/Paper forks this project supports — happy to help investigate that further if useful, but this unblocks the immediate crash with a minimal, low-risk change scoped to the bukkit module.

## Test plan

- [x] Built with `./gradlew :bootstrap:bukkit:shadowJar` (JDK 25 Temurin toolchain) — build succeeds
- [x] Verified `net/jodah/expiringmap/ExpiringMap.class` (and related classes) are present, unrelocated, in the resulting `BetterHud-bukkit-2.0.0.jar`
- [x] Deployed the patched jar to two production Purpur 26.1.2 servers that were both consistently crashing on every full restart with the `NoClassDefFoundError` above — pending final confirmation from a restart, but the classloading root cause (class simply isn't in the jar or reachable via the runtime injector) is fixed by construction since the class now ships in the jar itself