### PR TITLE
perf: skip unchanged HUD boss bar updates

### DIFF
--- a/dist/build.gradle.kts
+++ b/dist/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     compileOnly(libs.bundles.adventure)
     compileOnly(libs.bundles.library)
 
+    testImplementation(libs.bundles.adventure)
     testImplementation(libs.bundles.library)
 
     compileOnly("me.lucko:jar-relocator:1.7")

--- a/dist/src/main/kotlin/kr/toxicity/hud/player/HudPlayerImpl.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/player/HudPlayerImpl.kt
@@ -19,6 +19,7 @@ import kotlin.collections.forEach
 abstract class HudPlayerImpl : HudPlayer {
     private val locationSet = HashSet<PointedLocation>()
     private val componentMap = ConcurrentHashMap<HudObject.Identifier, HudComponentSupplier<*>>()
+    private val renderCache = HudRenderCache()
 
     private var tick = 0L
     private var last: WidthComponent = EMPTY_WIDTH_COMPONENT
@@ -125,7 +126,7 @@ abstract class HudPlayerImpl : HudPlayer {
                 } else compList += comp
             }
         }
-        if (compList.isNotEmpty() || additionalComp != null) {
+        val component = if (compList.isNotEmpty() || additionalComp != null) {
             additionalComp?.let {
                 compList += (-it.width / 2).toSpaceComponent() + it
             }
@@ -135,12 +136,16 @@ abstract class HudPlayerImpl : HudPlayer {
                 comp += (-it.width).toSpaceComponent()
             }
             last = comp.finalizeFont()
-
-            VOLATILE_CODE.showBossBar(this, color ?: ShaderManagerImpl.barColor, comp.component.build().compact())
-        } else VOLATILE_CODE.showBossBar(this, color ?: ShaderManagerImpl.barColor, EMPTY_COMPONENT)
+            comp.component.build()
+        } else EMPTY_COMPONENT
+        val barColor = color ?: ShaderManagerImpl.barColor
+        if (renderCache.shouldUpdate(component, barColor, ConfigManagerImpl.forceUpdate)) {
+            VOLATILE_CODE.showBossBar(this, barColor, component.compact())
+        }
     }
 
     override fun reload() {
+        renderCache.invalidate()
         autoSave.restart()
         locationProvide.restart()
         startTick()

--- a/dist/src/main/kotlin/kr/toxicity/hud/player/HudRenderCache.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/player/HudRenderCache.kt
@@ -1,0 +1,25 @@
+package kr.toxicity.hud.player
+
+import net.kyori.adventure.bossbar.BossBar
+import net.kyori.adventure.text.Component
+
+internal class HudRenderCache {
+    private var component: Component? = null
+    private var color: BossBar.Color? = null
+
+    @Synchronized
+    fun shouldUpdate(component: Component, color: BossBar.Color, force: Boolean): Boolean {
+        if (!force && component == this.component && color == this.color) {
+            return false
+        }
+        this.component = component
+        this.color = color
+        return true
+    }
+
+    @Synchronized
+    fun invalidate() {
+        component = null
+        color = null
+    }
+}

--- a/dist/src/test/kotlin/kr/toxicity/hud/player/HudRenderCacheTest.kt
+++ b/dist/src/test/kotlin/kr/toxicity/hud/player/HudRenderCacheTest.kt
@@ -1,0 +1,53 @@
+package kr.toxicity.hud.player
+
+import net.kyori.adventure.bossbar.BossBar
+import net.kyori.adventure.text.Component
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HudRenderCacheTest {
+    private val cache = HudRenderCache()
+
+    @Test
+    fun `first render requires an update`() {
+        assertTrue(cache.shouldUpdate(Component.empty(), BossBar.Color.WHITE, false))
+    }
+
+    @Test
+    fun `structurally equal components do not require another update`() {
+        assertTrue(cache.shouldUpdate(Component.text("same"), BossBar.Color.WHITE, false))
+        assertFalse(cache.shouldUpdate(Component.text("same"), BossBar.Color.WHITE, false))
+    }
+
+    @Test
+    fun `changed component requires an update`() {
+        assertTrue(cache.shouldUpdate(Component.text("first"), BossBar.Color.WHITE, false))
+        assertTrue(cache.shouldUpdate(Component.text("second"), BossBar.Color.WHITE, false))
+    }
+
+    @Test
+    fun `changed color requires an update`() {
+        val component = Component.text("same")
+        assertTrue(cache.shouldUpdate(component, BossBar.Color.WHITE, false))
+        assertTrue(cache.shouldUpdate(component, BossBar.Color.RED, false))
+    }
+
+    @Test
+    fun `forced renders always require an update`() {
+        val component = Component.text("same")
+        assertTrue(cache.shouldUpdate(component, BossBar.Color.WHITE, false))
+        assertTrue(cache.shouldUpdate(component, BossBar.Color.WHITE, true))
+    }
+
+    @Test
+    fun `invalidating cache requires another update`() {
+        val component = Component.text("same")
+        assertTrue(cache.shouldUpdate(component, BossBar.Color.WHITE, false))
+        assertFalse(cache.shouldUpdate(component, BossBar.Color.WHITE, false))
+
+        cache.invalidate()
+
+        assertTrue(cache.shouldUpdate(component, BossBar.Color.WHITE, false))
+    }
+}


### PR DESCRIPTION
## Summary
- cache the last immutable Adventure component and boss bar color rendered for each HUD player
- skip `Component.compact()` and the volatile `showBossBar` path when the rendered HUD is structurally unchanged
- preserve unconditional updates when `force-update` is enabled and invalidate the cache on reload
- add unit coverage for initial, unchanged, changed, forced, color-change, and invalidated renders

## Motivation
BetterHud previously rebuilt and sent the boss bar name on every update, even when the rendered component was identical. On a 101-player server this caused the NMS boss bar path to repeatedly serialize Adventure components to JSON and parse them back into native Minecraft components.

Allocation profiles with the same player count showed:

| Allocation path | Before | After |
| --- | ---: | ---: |
| `HudPlayerImpl.update()` | 803.1 MB/s | 263.6 MB/s |
| `NMSImpl.showBossBar()` | 467.1 MB/s | 5.2 MB/s |
| `Component.compact()` | 56.7 MB/s | 0.6 MB/s |

Before: https://spark.lucko.me/Ull2L11gpM

After: https://spark.lucko.me/2LTVbeNaBa

The remaining render/supplier work is unchanged; this PR only avoids compacting, converting, and sending an identical final HUD.

## Testing
- `./gradlew :dist:test`
- 7 tests passed, including 6 new cache behavior tests